### PR TITLE
fix: change pr link to redirect url

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -96854,6 +96854,8 @@ var __webpack_exports__ = {};
             if (isPR && projectReports.length > 0) {
                 const { context } = __webpack_require__("./node_modules/.pnpm/@actions+github@4.0.0/node_modules/@actions/github/lib/github.js");
                 let commentBody = '## Rsdoctor Bundle Diff Analysis\n\n';
+                const repoSlug = process.env.GITHUB_REPOSITORY || 'OWNER/REPO';
+                commentBody += `> 🧪 **Example PR/MR:** [#19](https://redirect.github.com/${repoSlug}/pull/19)\n\n`;
                 const firstReport = projectReports.find((r)=>r.current);
                 if (firstReport?.baselineUsedFallback && firstReport?.baselineLatestCommitHash) commentBody += `> ⚠️ **Note:** The latest commit (\`${firstReport.baselineLatestCommitHash}\`) does not have baseline artifacts. Using commit \`${firstReport.baselineCommitHash}\` for baseline comparison instead. If this seems incorrect, please wait a few minutes and try rerunning the workflow.\n\n`;
                 const reportsWithCurrent = projectReports.filter((r)=>r.current);

--- a/dist/index.js
+++ b/dist/index.js
@@ -96854,8 +96854,6 @@ var __webpack_exports__ = {};
             if (isPR && projectReports.length > 0) {
                 const { context } = __webpack_require__("./node_modules/.pnpm/@actions+github@4.0.0/node_modules/@actions/github/lib/github.js");
                 let commentBody = '## Rsdoctor Bundle Diff Analysis\n\n';
-                const repoSlug = process.env.GITHUB_REPOSITORY || 'OWNER/REPO';
-                commentBody += `> 🧪 **Example PR/MR:** [#19](https://redirect.github.com/${repoSlug}/pull/19)\n\n`;
                 const firstReport = projectReports.find((r)=>r.current);
                 if (firstReport?.baselineUsedFallback && firstReport?.baselineLatestCommitHash) commentBody += `> ⚠️ **Note:** The latest commit (\`${firstReport.baselineLatestCommitHash}\`) does not have baseline artifacts. Using commit \`${firstReport.baselineCommitHash}\` for baseline comparison instead. If this seems incorrect, please wait a few minutes and try rerunning the workflow.\n\n`;
                 const reportsWithCurrent = projectReports.filter((r)=>r.current);

--- a/dist/index.js
+++ b/dist/index.js
@@ -16019,13 +16019,13 @@ The following characters are not allowed in files that are uploaded due to limit
             listEnumValues: ()=>listEnumValues,
             assertNever: ()=>assert.xb,
             mergeBinaryOptions: ()=>binary_format_contract.Ix,
+            reflectionScalarDefault: ()=>reflectionScalarDefault,
             lowerCamelCase: ()=>lower_camel_case.W,
             PbULong: ()=>PbULong,
             LongType: ()=>reflection_info_LongType,
             MessageType: ()=>MessageType,
             ScalarType: ()=>reflection_info_ScalarType,
             readFieldOptions: ()=>readFieldOptions,
-            reflectionScalarDefault: ()=>reflectionScalarDefault,
             WireType: ()=>binary_format_contract.O0,
             containsMessageType: ()=>containsMessageType,
             listEnumNumbers: ()=>listEnumNumbers,
@@ -96206,6 +96206,16 @@ var __webpack_exports__ = {};
             throw downloadError;
         }
     }
+    function toGitHubRedirectUrl(url) {
+        if (!url) return url;
+        if (url.startsWith('https://redirect.github.com/')) return url;
+        try {
+            const u = new URL(url);
+            return `https://redirect.github.com${u.pathname}${u.search}${u.hash}`;
+        } catch  {
+            return url;
+        }
+    }
     function formatBytes(bytes) {
         if (0 === bytes) return '0 B';
         const k = 1024;
@@ -96335,7 +96345,7 @@ var __webpack_exports__ = {};
                 const commitLink = `${process.env.GITHUB_SERVER_URL || 'https://github.com'}/${process.env.GITHUB_REPOSITORY}/commit/${baselineCommitHash}`;
                 let baselineInfo = `> 📌 **Baseline Commit:** [\`${baselineCommitHash}\`](${commitLink})`;
                 if (baselinePRs && baselinePRs.length > 0) {
-                    const prLinks = baselinePRs.map((pr)=>`[#${pr.number}](${pr.url})`).join(', ');
+                    const prLinks = baselinePRs.map((pr)=>`[#${pr.number}](${toGitHubRedirectUrl(pr.url)})`).join(', ');
                     baselineInfo += ` | **PR:** ${prLinks}`;
                 }
                 markdown += `${baselineInfo}\n\n`;
@@ -96357,7 +96367,7 @@ var __webpack_exports__ = {};
                 const commitLink = `${process.env.GITHUB_SERVER_URL || 'https://github.com'}/${process.env.GITHUB_REPOSITORY}/commit/${baselineCommitHash}`;
                 let baselineInfo = `> 📌 **Baseline Commit:** [\`${baselineCommitHash}\`](${commitLink})`;
                 if (baselinePRs && baselinePRs.length > 0) {
-                    const prLinks = baselinePRs.map((pr)=>`[#${pr.number}](${pr.url})`).join(', ');
+                    const prLinks = baselinePRs.map((pr)=>`[#${pr.number}](${toGitHubRedirectUrl(pr.url)})`).join(', ');
                     baselineInfo += ` | **PR:** ${prLinks}`;
                 }
                 await core.summary.addRaw(baselineInfo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,10 +437,6 @@ async function processSingleFile(
       const { context } = require('@actions/github');
       
       let commentBody = '## Rsdoctor Bundle Diff Analysis\n\n';
-
-      // Example PR/MR link (use redirect.github.com to avoid auto-association)
-      const repoSlug = process.env.GITHUB_REPOSITORY || 'OWNER/REPO';
-      commentBody += `> 🧪 **Example PR/MR:** [#19](https://redirect.github.com/${repoSlug}/pull/19)\n\n`;
       
       // Add fallback notice if applicable (check first report)
       const firstReport = projectReports.find(r => r.current);

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,6 +437,10 @@ async function processSingleFile(
       const { context } = require('@actions/github');
       
       let commentBody = '## Rsdoctor Bundle Diff Analysis\n\n';
+
+      // Example PR/MR link (use redirect.github.com to avoid auto-association)
+      const repoSlug = process.env.GITHUB_REPOSITORY || 'OWNER/REPO';
+      commentBody += `> 🧪 **Example PR/MR:** [#19](https://redirect.github.com/${repoSlug}/pull/19)\n\n`;
       
       // Add fallback notice if applicable (check first report)
       const firstReport = projectReports.find(r => r.current);

--- a/src/report.ts
+++ b/src/report.ts
@@ -49,6 +49,19 @@ export interface BundleAnalysis {
   }>;
 }
 
+function toGitHubRedirectUrl(url: string): string {
+  // Keep link clickable but avoid GitHub auto-associating PR references in comments.
+  // Example: https://github.com/org/repo/pull/123 -> https://redirect.github.com/org/repo/pull/123
+  if (!url) return url;
+  if (url.startsWith('https://redirect.github.com/')) return url;
+  try {
+    const u = new URL(url);
+    return `https://redirect.github.com${u.pathname}${u.search}${u.hash}`;
+  } catch {
+    return url;
+  }
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B';
   
@@ -210,7 +223,9 @@ export function generateProjectMarkdown(
     
     // Add PR links if available
     if (baselinePRs && baselinePRs.length > 0) {
-      const prLinks = baselinePRs.map(pr => `[#${pr.number}](${pr.url})`).join(', ');
+      const prLinks = baselinePRs
+        .map(pr => `[#${pr.number}](${toGitHubRedirectUrl(pr.url)})`)
+        .join(', ');
       baselineInfo += ` | **PR:** ${prLinks}`;
     }
     
@@ -247,7 +262,9 @@ export async function generateBundleAnalysisReport(
       
       // Add PR links if available
       if (baselinePRs && baselinePRs.length > 0) {
-        const prLinks = baselinePRs.map(pr => `[#${pr.number}](${pr.url})`).join(', ');
+        const prLinks = baselinePRs
+          .map(pr => `[#${pr.number}](${toGitHubRedirectUrl(pr.url)})`)
+          .join(', ');
         baselineInfo += ` | **PR:** ${prLinks}`;
       }
       


### PR DESCRIPTION
fix: change pr link to redirect url

This pull request improves how pull request (PR) links are displayed in bundle analysis reports and comments, ensuring that GitHub does not auto-associate these links with issues or PRs by using redirect URLs. The changes introduce a utility function for generating redirect links and update all PR link generation to use this function.

**Improvements to PR Link Handling:**

* Added a `toGitHubRedirectUrl` utility function in `src/report.ts` to convert standard GitHub PR URLs to `redirect.github.com` URLs, preventing GitHub from auto-associating PR references in comments.
* Updated PR link generation in both `generateProjectMarkdown` and `generateBundleAnalysisReport` functions in `src/report.ts` to use the new redirect URL utility, ensuring all PR links in reports use the safer redirect format. [[1]](diffhunk://#diff-261d868c0270a5f101f89250300b90d764d0d6dc2ecee7391c03b271eade14bdL213-R228) [[2]](diffhunk://#diff-261d868c0270a5f101f89250300b90d764d0d6dc2ecee7391c03b271eade14bdL250-R267)
* Modified the comment body in `processSingleFile` in `src/index.ts` to include an example PR/MR link using the redirect URL format, further illustrating the new approach and preventing unintended associations.