### PR TITLE
fix: disambiguate project names for multi-entry builds

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -95640,6 +95640,10 @@ function __webpack_require__(moduleId) {
 var __webpack_exports__ = {};
 (()=>{
     "use strict";
+    __webpack_require__.r(__webpack_exports__);
+    __webpack_require__.d(__webpack_exports__, {
+        extractProjectName: ()=>extractProjectName
+    });
     var core = __webpack_require__("./node_modules/.pnpm/@actions+core@1.11.1/node_modules/@actions/core/lib/core.js");
     var lib_artifact = __webpack_require__("./node_modules/.pnpm/@actions+artifact@2.3.2/node_modules/@actions/artifact/lib/artifact.js");
     var external_path_ = __webpack_require__("path");
@@ -96636,9 +96640,21 @@ var __webpack_exports__ = {};
             'examples'
         ];
         const patternIndex = pathParts.findIndex((part)=>monorepoPatterns.includes(part));
-        if (patternIndex >= 0 && patternIndex + 1 < pathParts.length) for(let i = patternIndex + 1; i < pathParts.length; i++){
-            const part = pathParts[i];
-            if (!buildOutputDirs.includes(part)) return part;
+        if (patternIndex >= 0 && patternIndex + 1 < pathParts.length) {
+            let packageName = null;
+            let packageNameIndex = -1;
+            for(let i = patternIndex + 1; i < pathParts.length; i++)if (!buildOutputDirs.includes(pathParts[i])) {
+                packageName = pathParts[i];
+                packageNameIndex = i;
+                break;
+            }
+            if (packageName) {
+                for(let i = pathParts.length - 2; i > packageNameIndex; i--){
+                    const part = pathParts[i];
+                    if (!buildOutputDirs.includes(part)) return `${packageName}/${part}`;
+                }
+                return packageName;
+            }
         }
         for(let i = pathParts.length - 2; i >= 0; i--){
             const part = pathParts[i];
@@ -96953,7 +96969,10 @@ var __webpack_exports__ = {};
         }
     })();
 })();
-for(var __webpack_i__ in __webpack_exports__)exports[__webpack_i__] = __webpack_exports__[__webpack_i__];
+exports.extractProjectName = __webpack_exports__.extractProjectName;
+for(var __webpack_i__ in __webpack_exports__)if (-1 === [
+    "extractProjectName"
+].indexOf(__webpack_i__)) exports[__webpack_i__] = __webpack_exports__[__webpack_i__];
 Object.defineProperty(exports, '__esModule', {
     value: true
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -96746,7 +96746,8 @@ var __webpack_exports__ = {};
                     console.log(`⚠️ npx approach also failed: ${npxError}`);
                 }
             }
-            const diffHtmlPath = external_path_default().join(tempOutDir, `rsdoctor-diff-${projectName}.html`);
+            const safeProjectName = projectName.replace(/\//g, '-');
+            const diffHtmlPath = external_path_default().join(tempOutDir, `rsdoctor-diff-${safeProjectName}.html`);
             const defaultDiffPath = external_path_default().join(tempOutDir, 'rsdoctor-diff.html');
             if (external_fs_.existsSync(defaultDiffPath)) try {
                 await external_fs_.promises.rename(defaultDiffPath, diffHtmlPath);

--- a/src/__tests__/extractProjectName.test.ts
+++ b/src/__tests__/extractProjectName.test.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+import { describe, it, expect } from '@rstest/core';
+import { extractProjectName } from '../index';
+
+describe('extractProjectName', () => {
+  describe('monorepo - single entry (default .rsdoctor output)', () => {
+    it('should return package name only', () => {
+      const filePath = path.join(process.cwd(), 'packages/adapter-rsbuild/dist/.rsdoctor/rsdoctor-data.json');
+      expect(extractProjectName(filePath)).toBe('adapter-rsbuild');
+    });
+
+    it('should work with apps/ pattern', () => {
+      const filePath = path.join(process.cwd(), 'apps/web/dist/.rsdoctor/rsdoctor-data.json');
+      expect(extractProjectName(filePath)).toBe('web');
+    });
+  });
+
+  describe('monorepo - multi entry with custom reportDir', () => {
+    it('should return packageName/suffix for different entries', () => {
+      const mainPath = path.join(process.cwd(), 'packages/core/dist/rsdoctor-main/rsdoctor-data.json');
+      const loadersPath = path.join(process.cwd(), 'packages/core/dist/rsdoctor-loaders/rsdoctor-data.json');
+      const browserPath = path.join(process.cwd(), 'packages/core/dist/rsdoctor-browser/rsdoctor-data.json');
+
+      expect(extractProjectName(mainPath)).toBe('core/rsdoctor-main');
+      expect(extractProjectName(loadersPath)).toBe('core/rsdoctor-loaders');
+      expect(extractProjectName(browserPath)).toBe('core/rsdoctor-browser');
+    });
+
+    it('should work with nested custom dirs', () => {
+      const filePath = path.join(process.cwd(), 'packages/vscode/dist/rsdoctor-extension/rsdoctor-data.json');
+      expect(extractProjectName(filePath)).toBe('vscode/rsdoctor-extension');
+    });
+  });
+
+  describe('non-monorepo', () => {
+    it('should use parent directory name from fallback logic', () => {
+      const filePath = path.join(process.cwd(), 'dist/rsdoctor-main/rsdoctor-data.json');
+      expect(extractProjectName(filePath)).toBe('rsdoctor-main');
+    });
+
+    it('should handle default .rsdoctor output dir', () => {
+      const filePath = path.join(process.cwd(), 'dist/.rsdoctor/rsdoctor-data.json');
+      expect(extractProjectName(filePath)).toBe('dist');
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,7 +247,8 @@ async function processSingleFile(
         }
       }
 
-      const diffHtmlPath = path.join(tempOutDir, `rsdoctor-diff-${projectName}.html`);
+      const safeProjectName = projectName.replace(/\//g, '-');
+      const diffHtmlPath = path.join(tempOutDir, `rsdoctor-diff-${safeProjectName}.html`);
       const defaultDiffPath = path.join(tempOutDir, 'rsdoctor-diff.html');
       if (fs.existsSync(defaultDiffPath)) {
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ interface ProjectReport {
   baselineLatestCommitHash?: string;
 }
 
-function extractProjectName(filePath: string): string {
+export function extractProjectName(filePath: string): string {
   const relativePath = path.relative(process.cwd(), filePath);
   const pathParts = relativePath.split(path.sep);
   
@@ -111,11 +111,24 @@ function extractProjectName(filePath: string): string {
   const patternIndex = pathParts.findIndex(part => monorepoPatterns.includes(part));
   
   if (patternIndex >= 0 && patternIndex + 1 < pathParts.length) {
+    let packageName: string | null = null;
+    let packageNameIndex = -1;
     for (let i = patternIndex + 1; i < pathParts.length; i++) {
-      const part = pathParts[i];
-      if (!buildOutputDirs.includes(part)) {
-        return part;
+      if (!buildOutputDirs.includes(pathParts[i])) {
+        packageName = pathParts[i];
+        packageNameIndex = i;
+        break;
       }
+    }
+
+    if (packageName) {
+      for (let i = pathParts.length - 2; i > packageNameIndex; i--) {
+        const part = pathParts[i];
+        if (!buildOutputDirs.includes(part)) {
+          return `${packageName}/${part}`;
+        }
+      }
+      return packageName;
     }
   }
   


### PR DESCRIPTION
## Problem

`extractProjectName` in the monorepo branch returns the package name immediately after matching `packages/`, ignoring the rest of the path. When a package has multiple build entries each outputting to a different `reportDir` (e.g. `dist/rsdoctor-main/`, `dist/rsdoctor-loaders/`), the PR comment Quick Summary table shows multiple rows with the same name, making them indistinguishable.

Example: https://github.com/web-infra-dev/rstest/pull/1086#issuecomment-4109993734

This also caused only the first entry to have a "Download Diff Report" button ([example](https://github.com/web-infra-dev/rstest/pull/1087#issuecomment-4116618153)). Because all entries shared the same `projectName`, the diff HTML was renamed to the same filename (`rsdoctor-diff-core.html`), producing identical artifact names. The 2nd/3rd uploads failed due to duplicate artifact names within the same workflow run, so only the first report got a `diffHtmlArtifactId`.

## Fix

After extracting the package name in the monorepo branch, continue scanning the remaining path segments (back to front) for a non-build-output directory to use as a suffix, returning `packageName/suffix`. The `/` is replaced with `-` when composing the diff HTML filename to avoid creating nested paths.

This resolves both issues:
1. **Duplicate display names** — each entry now has a unique name (e.g. `core/rsdoctor-main`, `core/rsdoctor-loaders`)
2. **Missing download buttons** — unique names produce unique diff HTML filenames and artifact hashes, so all uploads succeed

### Before
| Project | Total Size | Change |
|---------|------------|--------|
| core | 1.2 MB | +10 KB |
| core | 800 KB | -5 KB |
| core | 200 KB | 0 |

### After
| Project | Total Size | Change |
|---------|------------|--------|
| core/rsdoctor-main | 1.2 MB | +10 KB |
| core/rsdoctor-loaders | 800 KB | -5 KB |
| core/rsdoctor-browser | 200 KB | 0 |

Single-entry packages (e.g. `packages/adapter-rsbuild/dist/.rsdoctor/rsdoctor-data.json`) are unaffected and still display as `adapter-rsbuild`.

## Changes

- `src/index.ts`: Refactored `extractProjectName` monorepo branch; sanitize `projectName` in diff HTML filename
- `src/__tests__/extractProjectName.test.ts`: Added 6 unit tests
- `dist/index.js`: Rebuilt