### PR TITLE
fix: optimize artifact names

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -96153,9 +96153,13 @@ var __webpack_exports__ = {};
     var external_fs_ = __webpack_require__("fs");
     var external_child_process_ = __webpack_require__("child_process");
     var external_crypto_ = __webpack_require__("crypto");
+    const ARTIFACT_NAME_PREFIX = 'rsdoctor';
     function hashPath(pathParts, fileNameWithoutExt) {
         const pathString = `${pathParts.join('-')}-${fileNameWithoutExt}`;
         return (0, external_crypto_.createHash)('sha256').update(pathString).digest('hex').substring(0, 8);
+    }
+    function createArtifactName(pathHash, commitHash) {
+        return `${ARTIFACT_NAME_PREFIX}-${pathHash}-${commitHash}`;
     }
     async function uploadArtifact(filePath, commitHash) {
         const artifactClient = new lib_artifact.DefaultArtifactClient();
@@ -96169,7 +96173,7 @@ var __webpack_exports__ = {};
         const pathParts = relativePath.split(external_path_default().sep);
         const fileNameWithoutExt = external_path_default().parse(fileName).name;
         const pathHash = hashPath(pathParts, fileNameWithoutExt);
-        const artifactName = `${pathHash}-${hash}`;
+        const artifactName = createArtifactName(pathHash, hash);
         console.log(`Uploading artifact: ${artifactName}`);
         console.log(`From file: ${targetFilePath}`);
         const uploadResponse = await artifactClient.uploadArtifact(artifactName, [
@@ -96637,8 +96641,11 @@ var __webpack_exports__ = {};
         const fileNameWithoutExt = external_path_default().parse(fileName).name;
         const fileExt = external_path_default().parse(fileName).ext;
         const pathHash = hashPath(pathParts, fileNameWithoutExt);
-        const expectedArtifactName = `${pathHash}-${commitHash}`;
-        const legacyArtifactName = `${pathHash}-${commitHash}${fileExt}`;
+        const expectedArtifactName = createArtifactName(pathHash, commitHash);
+        const legacyArtifactNames = [
+            `${pathHash}-${commitHash}`,
+            `${pathHash}-${commitHash}${fileExt}`
+        ];
         console.log(`📋 Searching for artifact with path hash and commit hash: ${expectedArtifactName}`);
         console.log(`   Path hash: ${pathHash}`);
         console.log(`   File path: ${relativePath}`);
@@ -96653,7 +96660,7 @@ var __webpack_exports__ = {};
                 console.log(`   Status: ${workflowRun.status}, Conclusion: ${workflowRun.conclusion}`);
                 try {
                     const runArtifacts = await githubService.listArtifactsForWorkflowRun(workflowRun.id);
-                    const foundArtifact = runArtifacts.artifacts?.find((a)=>a.name === expectedArtifactName || a.name === legacyArtifactName);
+                    const foundArtifact = runArtifacts.artifacts?.find((a)=>a.name === expectedArtifactName || legacyArtifactNames.includes(a.name));
                     if (foundArtifact) {
                         artifact = foundArtifact;
                         artifacts = runArtifacts;
@@ -96679,7 +96686,7 @@ var __webpack_exports__ = {};
         }
         if (!artifact) {
             artifacts = await githubService.listArtifacts();
-            artifact = artifacts.artifacts.find((a)=>a.name === expectedArtifactName || a.name === legacyArtifactName);
+            artifact = artifacts.artifacts.find((a)=>a.name === expectedArtifactName || legacyArtifactNames.includes(a.name));
         }
         if (!artifact) {
             console.log(`❌ No artifact found matching: ${expectedArtifactName}`);

--- a/src/__tests__/download.test.ts
+++ b/src/__tests__/download.test.ts
@@ -1,0 +1,90 @@
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@rstest/core';
+import { downloadArtifactByCommitHash } from '../download';
+import { createArtifactName, hashPath } from '../upload';
+import { mockConsole, restoreConsole } from './mock-console';
+const nock = require('nock');
+
+describe('Download Module', () => {
+  const commitHash = 'abc1234567';
+  const filePath = '/tmp/test/rsdoctor-data.json';
+  const fileName = 'rsdoctor-data.json';
+  const workflowRunId = 123;
+
+  beforeEach(() => {
+    mockConsole();
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    restoreConsole();
+  });
+
+  function getPathHash() {
+    const relativePath = path.relative(process.cwd(), filePath);
+    const pathParts = relativePath.split(path.sep);
+    return hashPath(pathParts, 'rsdoctor-data');
+  }
+
+  function mockArtifactSearch(artifactName: string, artifactId: number) {
+    nock('https://api.github.com')
+      .get('/repos/web-infra-dev/rsdoctor-action/actions/runs')
+      .query({ head_sha: commitHash, status: 'completed', per_page: 30 })
+      .reply(200, {
+        workflow_runs: [
+          {
+            id: workflowRunId,
+            name: 'CI',
+            status: 'completed',
+            conclusion: 'success',
+          },
+        ],
+      });
+
+    nock('https://api.github.com')
+      .get(`/repos/web-infra-dev/rsdoctor-action/actions/runs/${workflowRunId}/artifacts`)
+      .reply(200, {
+        artifacts: [
+          {
+            id: artifactId,
+            name: artifactName,
+            created_at: '2026-05-08T00:00:00Z',
+            size_in_bytes: 100,
+          },
+        ],
+      });
+
+    return nock('https://api.github.com')
+      .get(`/repos/web-infra-dev/rsdoctor-action/actions/artifacts/${artifactId}/zip`)
+      .reply(200, Buffer.from('not a zip'));
+  }
+
+  it('should find artifacts that use the rsdoctor-prefixed name', async () => {
+    const pathHash = getPathHash();
+    const artifactName = createArtifactName(pathHash, commitHash);
+    const downloadScope = mockArtifactSearch(artifactName, 101);
+
+    await expect(downloadArtifactByCommitHash(commitHash, fileName, filePath)).rejects.toThrow();
+
+    expect(downloadScope.isDone()).toBe(true);
+  });
+
+  it('should find artifacts that use the legacy unprefixed name', async () => {
+    const pathHash = getPathHash();
+    const downloadScope = mockArtifactSearch(`${pathHash}-${commitHash}`, 202);
+
+    await expect(downloadArtifactByCommitHash(commitHash, fileName, filePath)).rejects.toThrow();
+
+    expect(downloadScope.isDone()).toBe(true);
+  });
+
+  it('should find artifacts that use the legacy unprefixed name with extension', async () => {
+    const pathHash = getPathHash();
+    const downloadScope = mockArtifactSearch(`${pathHash}-${commitHash}.json`, 303);
+
+    await expect(downloadArtifactByCommitHash(commitHash, fileName, filePath)).rejects.toThrow();
+
+    expect(downloadScope.isDone()).toBe(true);
+  });
+});

--- a/src/__tests__/upload.test.ts
+++ b/src/__tests__/upload.test.ts
@@ -49,8 +49,13 @@ describe('Upload Module', () => {
       .toThrow('Target file not found');
   });
 
-  it('should generate correct artifact name', async () => {
+  it('should prefix artifact name with rsdoctor for easier cleanup', async () => {
     const result = await uploadArtifact(mockFilePath, mockCommitHash);
+    const relativePath = path.relative(process.cwd(), mockFilePath);
+    const pathParts = relativePath.split(path.sep);
+    const pathHash = hashPath(pathParts, 'rsdoctor-data');
+
+    expect(console.log).toHaveBeenCalledWith(`Uploading artifact: rsdoctor-${pathHash}-${mockCommitHash}`);
     expect(result).toBeDefined();
     expect(result.id).toBe(1);
   });
@@ -89,4 +94,3 @@ describe('Upload Module', () => {
     });
   });
 });
-

--- a/src/download.ts
+++ b/src/download.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import * as fs from 'fs';
 import { GitHubService } from './github';
 import * as yauzl from 'yauzl';
-import { hashPath } from './upload';
+import { createArtifactName, hashPath } from './upload';
 
 export async function downloadArtifact(artifactId: number, fileName: string) {
   console.log(`📥 Downloading artifact ID: ${artifactId}`);
@@ -106,9 +106,12 @@ export async function downloadArtifactByCommitHash(
   const fileNameWithoutExt = path.parse(fileName).name;
   const fileExt = path.parse(fileName).ext;
   const pathHash = hashPath(pathParts, fileNameWithoutExt);
-  // New format (no extension); legacy format includes the file extension
-  const expectedArtifactName = `${pathHash}-${commitHash}`;
-  const legacyArtifactName = `${pathHash}-${commitHash}${fileExt}`;
+  const expectedArtifactName = createArtifactName(pathHash, commitHash);
+  // Legacy formats were used before artifact names were prefixed for cleanup.
+  const legacyArtifactNames = [
+    `${pathHash}-${commitHash}`,
+    `${pathHash}-${commitHash}${fileExt}`,
+  ];
 
   console.log(`📋 Searching for artifact with path hash and commit hash: ${expectedArtifactName}`);
   console.log(`   Path hash: ${pathHash}`);
@@ -131,7 +134,9 @@ export async function downloadArtifactByCommitHash(
       
       try {
         const runArtifacts = await githubService.listArtifactsForWorkflowRun(workflowRun.id);
-        const foundArtifact = runArtifacts.artifacts?.find((a: any) => a.name === expectedArtifactName || a.name === legacyArtifactName);
+        const foundArtifact = runArtifacts.artifacts?.find(
+          (a: any) => a.name === expectedArtifactName || legacyArtifactNames.includes(a.name),
+        );
         
         if (foundArtifact) {
           artifact = foundArtifact;
@@ -160,7 +165,9 @@ export async function downloadArtifactByCommitHash(
   // Fallback: if not found in any workflow run, search all repository artifacts
   if (!artifact) {
     artifacts = await githubService.listArtifacts();
-    artifact = artifacts.artifacts.find((a: any) => a.name === expectedArtifactName || a.name === legacyArtifactName);
+    artifact = artifacts.artifacts.find(
+      (a: any) => a.name === expectedArtifactName || legacyArtifactNames.includes(a.name),
+    );
   }
   
   if (!artifact) {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -4,9 +4,15 @@ import * as fs from 'fs';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
 
+export const ARTIFACT_NAME_PREFIX = 'rsdoctor';
+
 export function hashPath(pathParts: string[], fileNameWithoutExt: string): string {
   const pathString = `${pathParts.join('-')}-${fileNameWithoutExt}`;
   return createHash('sha256').update(pathString).digest('hex').substring(0, 8);
+}
+
+export function createArtifactName(pathHash: string, commitHash: string): string {
+  return `${ARTIFACT_NAME_PREFIX}-${pathHash}-${commitHash}`;
 }
 
 export async function uploadArtifact(filePath: string, commitHash?: string) {
@@ -26,7 +32,7 @@ export async function uploadArtifact(filePath: string, commitHash?: string) {
   const fileNameWithoutExt = path.parse(fileName).name;
 
   const pathHash = hashPath(pathParts, fileNameWithoutExt);
-  const artifactName = `${pathHash}-${hash}`;
+  const artifactName = createArtifactName(pathHash, hash);
   
   console.log(`Uploading artifact: ${artifactName}`);
   console.log(`From file: ${targetFilePath}`);


### PR DESCRIPTION
This pull request standardizes artifact naming by introducing a consistent prefix, making it easier to identify and clean up artifacts. It updates both upload and download logic to use the new naming convention and ensures backward compatibility with legacy artifact names. The changes also improve test coverage for the new behavior.

Artifact naming improvements:

* Added a new constant `ARTIFACT_NAME_PREFIX` and a `createArtifactName` function in `src/upload.ts` to generate artifact names with the `rsdoctor` prefix for easier cleanup.
* Updated `uploadArtifact` in `src/upload.ts` to use the new `createArtifactName` function, ensuring all new artifacts follow the standardized naming convention.

Download logic updates:

* Modified `downloadArtifactByCommitHash` in `src/download.ts` to search for artifacts using the new prefixed name, while still supporting legacy artifact names for backward compatibility. 
* Updated imports in `src/download.ts` to include `createArtifactName` alongside `hashPath`.

Testing improvements:

* Enhanced the upload module test in `src/__tests__/upload.test.ts` to verify that the artifact name is correctly prefixed and that the upload log message reflects the new naming scheme.

# Related
closes: #39 