### PR TITLE
feat: add gzip size reporting

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -96719,6 +96719,7 @@ var __webpack_exports__ = {};
             throw downloadError;
         }
     }
+    var external_zlib_ = __webpack_require__("zlib");
     function toGitHubRedirectUrl(url) {
         if (!url) return url;
         if (url.startsWith('https://redirect.github.com/')) return url;
@@ -96744,6 +96745,52 @@ var __webpack_exports__ = {};
         const i = Math.floor(Math.log(absBytes) / Math.log(k));
         const value1 = (absBytes / Math.pow(k, i)).toFixed(1);
         return `${isNegative ? '-' : ''}${value1} ${sizes[i]}`;
+    }
+    function formatOptionalBytes(bytes) {
+        return 'number' != typeof bytes || isNaN(bytes) ? '-' : formatBytes(bytes);
+    }
+    function calculateOptionalDiff(current, baseline) {
+        if ('number' != typeof current || 'number' != typeof baseline) return '-';
+        return calculateDiff(current, baseline).value;
+    }
+    function resolveAssetPath(assetPath, dataFilePath) {
+        const relativeDataPath = external_path_.relative(process.cwd(), dataFilePath);
+        const isDownloadedArtifact = 'temp-artifact' === relativeDataPath.split(external_path_.sep)[0];
+        const candidates = [
+            external_path_.isAbsolute(assetPath) && !isDownloadedArtifact ? assetPath : null,
+            isDownloadedArtifact ? null : external_path_.resolve(process.cwd(), assetPath),
+            external_path_.resolve(external_path_.dirname(dataFilePath), assetPath),
+            external_path_.resolve(external_path_.dirname(dataFilePath), '..', assetPath)
+        ].filter(Boolean);
+        return candidates.find((candidate)=>external_fs_.existsSync(candidate)) || null;
+    }
+    function getAssetGzipSize(asset, dataFilePath) {
+        if ('number' == typeof asset.gzipSize && !isNaN(asset.gzipSize)) return asset.gzipSize;
+        const assetPath = resolveAssetPath(asset.path, dataFilePath);
+        if (!assetPath) return;
+        return (0, external_zlib_.gzipSync)(external_fs_.readFileSync(assetPath)).length;
+    }
+    function enrichRsdoctorDataWithGzip(filePath) {
+        try {
+            if (!external_fs_.existsSync(filePath)) return false;
+            const data = JSON.parse(external_fs_.readFileSync(filePath, 'utf8'));
+            const assets = data.data?.chunkGraph?.assets;
+            if (!Array.isArray(assets)) return false;
+            let updated = false;
+            for (const asset of assets){
+                if ('number' == typeof asset.gzipSize && !isNaN(asset.gzipSize)) continue;
+                const gzipSize = getAssetGzipSize(asset, filePath);
+                if ('number' == typeof gzipSize) {
+                    asset.gzipSize = gzipSize;
+                    updated = true;
+                }
+            }
+            if (updated) external_fs_.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+            return updated;
+        } catch (error) {
+            console.warn(`Failed to enrich rsdoctor data with gzip sizes from ${filePath}:`, error);
+            return false;
+        }
     }
     function parseRsdoctorData(filePath) {
         try {
@@ -96772,23 +96819,41 @@ var __webpack_exports__ = {};
             let cssSize = 0;
             let htmlSize = 0;
             let otherSize = 0;
+            let totalGzipSize = 0;
+            let jsGzipSize = 0;
+            let cssGzipSize = 0;
+            let htmlGzipSize = 0;
+            let otherGzipSize = 0;
+            let hasGzipSize = false;
             const assetAnalysis = assets.reduce((acc, asset)=>{
                 if (excludedExtensions.some((ext)=>asset.path.endsWith(ext))) return acc;
                 totalSize += asset.size;
+                const gzipSize = getAssetGzipSize(asset, filePath);
+                if ('number' == typeof gzipSize) {
+                    totalGzipSize += gzipSize;
+                    hasGzipSize = true;
+                }
                 let type = 'other';
                 if (asset.path.endsWith('.js')) {
                     type = 'js';
                     jsSize += asset.size;
+                    if ('number' == typeof gzipSize) jsGzipSize += gzipSize;
                 } else if (asset.path.endsWith('.css')) {
                     type = 'css';
                     cssSize += asset.size;
+                    if ('number' == typeof gzipSize) cssGzipSize += gzipSize;
                 } else if (asset.path.endsWith('.html')) {
                     type = 'html';
                     htmlSize += asset.size;
-                } else otherSize += asset.size;
+                    if ('number' == typeof gzipSize) htmlGzipSize += gzipSize;
+                } else {
+                    otherSize += asset.size;
+                    if ('number' == typeof gzipSize) otherGzipSize += gzipSize;
+                }
                 acc.push({
                     path: asset.path,
                     size: asset.size,
+                    gzipSize,
                     type
                 });
                 return acc;
@@ -96804,6 +96869,11 @@ var __webpack_exports__ = {};
                 cssSize,
                 htmlSize,
                 otherSize,
+                totalGzipSize: hasGzipSize ? totalGzipSize : void 0,
+                jsGzipSize: hasGzipSize ? jsGzipSize : void 0,
+                cssGzipSize: hasGzipSize ? cssGzipSize : void 0,
+                htmlGzipSize: hasGzipSize ? htmlGzipSize : void 0,
+                otherGzipSize: hasGzipSize ? otherGzipSize : void 0,
                 assets: assetAnalysis,
                 chunks: chunkAnalysis
             };
@@ -96820,6 +96890,7 @@ var __webpack_exports__ = {};
             }
             const data = JSON.parse(external_fs_.readFileSync(filePath, 'utf8'));
             if (!data.totalSize && data.files) data.totalSize = data.files.reduce((sum, file)=>sum + (file.size || 0), 0);
+            if (!data.totalGzipSize && data.files?.some((file)=>'number' == typeof file.gzipSize)) data.totalGzipSize = data.files.reduce((sum, file)=>sum + (file.gzipSize || 0), 0);
             return data;
         } catch (error) {
             console.error(`Failed to load size data from ${filePath}:`, error);
@@ -96875,6 +96946,7 @@ var __webpack_exports__ = {};
         markdown += '| Metric | Current | Baseline | Change |\n';
         markdown += '|--------|---------|----------|--------|\n';
         markdown += `| 📊 Total Size | ${formatBytes(current.totalSize)} | ${baseline ? formatBytes(baseline.totalSize) : '-'} | ${baseline ? calculateDiff(current.totalSize, baseline.totalSize).value : '-'} |\n`;
+        markdown += `| 🗜️ Gzip Size | ${formatOptionalBytes(current.totalGzipSize)} | ${baseline ? formatOptionalBytes(baseline.totalGzipSize) : '-'} | ${baseline ? calculateOptionalDiff(current.totalGzipSize, baseline.totalGzipSize) : '-'} |\n`;
         markdown += `| 📄 JavaScript | ${formatBytes(current.jsSize)} | ${baseline ? formatBytes(baseline.jsSize) : '-'} | ${baseline ? calculateDiff(current.jsSize, baseline.jsSize).value : '-'} |\n`;
         markdown += `| 🎨 CSS | ${formatBytes(current.cssSize)} | ${baseline ? formatBytes(baseline.cssSize) : '-'} | ${baseline ? calculateDiff(current.cssSize, baseline.cssSize).value : '-'} |\n`;
         markdown += `| 🌐 HTML | ${formatBytes(current.htmlSize)} | ${baseline ? formatBytes(baseline.htmlSize) : '-'} | ${baseline ? calculateDiff(current.htmlSize, baseline.htmlSize).value : '-'} |\n`;
@@ -96929,6 +97001,24 @@ var __webpack_exports__ = {};
                 },
                 {
                     data: baseline ? calculateDiff(current.totalSize, baseline.totalSize).value : '0',
+                    header: false
+                }
+            ],
+            [
+                {
+                    data: '🗜️ Gzip Size',
+                    header: false
+                },
+                {
+                    data: formatOptionalBytes(current.totalGzipSize),
+                    header: false
+                },
+                {
+                    data: baseline ? formatOptionalBytes(baseline.totalGzipSize) : formatOptionalBytes(current.totalGzipSize),
+                    header: false
+                },
+                {
+                    data: baseline ? calculateOptionalDiff(current.totalGzipSize, baseline.totalGzipSize) : '0',
                     header: false
                 }
             ],
@@ -97041,9 +97131,24 @@ var __webpack_exports__ = {};
                 }
             ]
         ];
+        if ('number' == typeof current.totalGzipSize || 'number' == typeof baseline?.totalGzipSize) reportTable.push([
+            {
+                data: '🗜️ Gzip Size',
+                header: false
+            },
+            {
+                data: formatOptionalBytes(current.totalGzipSize),
+                header: false
+            },
+            {
+                data: baseline ? formatOptionalBytes(baseline.totalGzipSize) : '0',
+                header: false
+            }
+        ]);
         await core.summary.addTable(reportTable).addSeparator();
         if (current.files && current.files.length > 0) {
             await core.summary.addHeading('📄 File Details', 3);
+            const hasFileGzipSize = current.files.some((file)=>'number' == typeof file.gzipSize);
             const fileTable = [
                 [
                     {
@@ -97053,7 +97158,13 @@ var __webpack_exports__ = {};
                     {
                         data: 'Size',
                         header: true
-                    }
+                    },
+                    ...hasFileGzipSize ? [
+                        {
+                            data: 'Gzip Size',
+                            header: true
+                        }
+                    ] : []
                 ]
             ];
             for (const file of current.files)fileTable.push([
@@ -97064,7 +97175,13 @@ var __webpack_exports__ = {};
                 {
                     data: formatBytes(file.size),
                     header: false
-                }
+                },
+                ...hasFileGzipSize ? [
+                    {
+                        data: formatOptionalBytes(file.gzipSize),
+                        header: false
+                    }
+                ] : []
             ]);
             await core.summary.addTable(fileTable);
         }
@@ -128740,6 +128857,25 @@ ${diffStr}
         if (r.error) throw r.error;
         if (0 !== r.status) throw new Error(`rsdoctor exited with code ${r.status}`);
     }
+    function hasBundleAnalysisChange(current, baseline) {
+        if (!baseline) return true;
+        const hasMetricChanged = (currentSize, baselineSize)=>{
+            if ('number' != typeof currentSize || 'number' != typeof baselineSize) return false;
+            if (0 === baselineSize || isNaN(baselineSize)) return false;
+            return currentSize - baselineSize !== 0;
+        };
+        return hasMetricChanged(current.totalSize, baseline.totalSize) || hasMetricChanged(current.totalGzipSize, baseline.totalGzipSize);
+    }
+    function formatGzipSize(analysis) {
+        return 'number' == typeof analysis.totalGzipSize ? formatBytes(analysis.totalGzipSize) : '-';
+    }
+    function calculateGzipDiff(current, baseline) {
+        if ('number' != typeof current.totalGzipSize || 'number' != typeof baseline?.totalGzipSize) return {
+            value: '-',
+            emoji: ''
+        };
+        return calculateDiff(current.totalGzipSize, baseline.totalGzipSize);
+    }
     function extractProjectName(filePath) {
         const relativePath = external_path_default().relative(process.cwd(), filePath);
         const pathParts = relativePath.split(external_path_default().sep);
@@ -128967,6 +129103,7 @@ ${diffStr}
             if (isPush) {
                 console.log('🔄 Detected push event to target branch - uploading artifacts');
                 for (const fullPath of matchedFiles){
+                    enrichRsdoctorDataWithGzip(fullPath);
                     const uploadResponse = await uploadArtifact(fullPath, currentCommitHash);
                     if ('number' != typeof uploadResponse.id) console.warn(`⚠️ Artifact upload failed for ${fullPath}`);
                     else console.log(`✅ Successfully uploaded artifact with ID: ${uploadResponse.id}`);
@@ -129004,6 +129141,7 @@ ${diffStr}
                     const report = await processSingleFile(fullPath, currentCommitHash, targetCommitHash, baselineUsedFallback, baselineLatestCommitHash, aiToken, aiModel);
                     projectReports.push(report);
                     if (isDispatch) {
+                        enrichRsdoctorDataWithGzip(fullPath);
                         const uploadResponse = await uploadArtifact(fullPath, currentCommitHash);
                         if ('number' != typeof uploadResponse.id) console.warn(`⚠️ Artifact upload failed for ${fullPath}`);
                         else console.log(`✅ Successfully uploaded artifact with ID: ${uploadResponse.id}`);
@@ -129035,17 +129173,8 @@ ${diffStr}
                 const reportsWithCurrent = projectReports.filter((r)=>r.current);
                 if (reportsWithCurrent.length > 1) {
                     let projectsWithChanges = 0;
-                    for (const report of reportsWithCurrent){
-                        if (!report.current) continue;
-                        if (!report.baseline) {
-                            projectsWithChanges++;
-                            continue;
-                        }
-                        const currentSize = report.current.totalSize;
-                        const baselineSize = report.baseline.totalSize;
-                        if (0 === baselineSize || isNaN(baselineSize)) continue;
-                        const diff = currentSize - baselineSize;
-                        if (0 !== diff) projectsWithChanges++;
+                    for (const report of reportsWithCurrent)if (report.current) {
+                        if (hasBundleAnalysisChange(report.current, report.baseline)) projectsWithChanges++;
                     }
                     const totalProjects = reportsWithCurrent.length;
                     const projectWord = 1 === totalProjects ? 'project' : 'projects';
@@ -129054,25 +129183,16 @@ ${diffStr}
                 }
                 if (reportsWithCurrent.length > 0) {
                     let hasChanges = false;
-                    for (const report of reportsWithCurrent){
-                        if (!report.current) continue;
-                        if (!report.baseline) {
-                            hasChanges = true;
-                            break;
-                        }
-                        const currentSize = report.current.totalSize;
-                        const baselineSize = report.baseline.totalSize;
-                        if (0 === baselineSize || isNaN(baselineSize)) continue;
-                        const diff = currentSize - baselineSize;
-                        if (0 !== diff) {
+                    for (const report of reportsWithCurrent)if (report.current) {
+                        if (hasBundleAnalysisChange(report.current, report.baseline)) {
                             hasChanges = true;
                             break;
                         }
                     }
                     const detailsTag = hasChanges ? '<details open>\n' : '<details>\n';
                     commentBody += `${detailsTag}<summary><b>📊 Quick Summary</b></summary>\n\n`;
-                    commentBody += '| Project | Total Size | Change |\n';
-                    commentBody += '|---------|------------|--------|\n';
+                    commentBody += '| Project | Total Size | Gzip Size | Change | Gzip Change |\n';
+                    commentBody += '|---------|------------|-----------|--------|-------------|\n';
                     for (const report of reportsWithCurrent){
                         if (!report.current) continue;
                         const currentSize = report.current.totalSize;
@@ -129082,18 +129202,14 @@ ${diffStr}
                             emoji: ''
                         };
                         const sizeStr = formatBytes(currentSize);
-                        commentBody += `| ${report.projectName} | ${sizeStr} | ${diff.emoji} ${diff.value} |\n`;
+                        const gzipDiff = calculateGzipDiff(report.current, report.baseline);
+                        commentBody += `| ${report.projectName} | ${sizeStr} | ${formatGzipSize(report.current)} | ${diff.emoji} ${diff.value} | ${gzipDiff.emoji} ${gzipDiff.value} |\n`;
                     }
                     commentBody += '\n</details>\n\n';
                 }
                 const hasSignificantChanges = (report)=>{
                     if (!report.current) return false;
-                    if (!report.baseline) return true;
-                    const currentSize = report.current.totalSize;
-                    const baselineSize = report.baseline.totalSize;
-                    if (0 === baselineSize || isNaN(baselineSize)) return false;
-                    const diff = currentSize - baselineSize;
-                    return 0 !== diff;
+                    return hasBundleAnalysisChange(report.current, report.baseline);
                 };
                 const reportsWithChanges = projectReports.filter((report)=>{
                     if (!report.current) return false;

--- a/src/__tests__/__snapshots__/report.test.ts.snap
+++ b/src/__tests__/__snapshots__/report.test.ts.snap
@@ -10,6 +10,7 @@ exports[`Report Module > generateProjectMarkdown > should generate markdown with
 | Metric | Current | Baseline | Change |
 |--------|---------|----------|--------|
 | 📊 Total Size | 1.0 MB | - | - |
+| 🗜️ Gzip Size | 384.0 KB | - | - |
 | 📄 JavaScript | 512.0 KB | - | - |
 | 🎨 CSS | 256.0 KB | - | - |
 | 🌐 HTML | 128.0 KB | - | - |

--- a/src/__tests__/fixtures/rsdoctor-data.json
+++ b/src/__tests__/fixtures/rsdoctor-data.json
@@ -6,12 +6,14 @@
           "id": 1,
           "path": "dist/static/js/index.js",
           "size": 52428800,
+          "gzipSize": 10485760,
           "chunks": ["index"]
         },
         {
           "id": 2,
           "path": "dist/static/css/index.css",
           "size": 10485760,
+          "gzipSize": 1048576,
           "chunks": ["index"]
         },
         {
@@ -45,4 +47,3 @@
     }
   }
 }
-

--- a/src/__tests__/report.test.ts
+++ b/src/__tests__/report.test.ts
@@ -17,6 +17,9 @@ describe('Report Module', () => {
       expect(result?.totalSize).toBe(62914560);
       expect(result?.jsSize).toBe(52428800);
       expect(result?.cssSize).toBe(10485760);
+      expect(result?.totalGzipSize).toBe(11534336);
+      expect(result?.jsGzipSize).toBe(10485760);
+      expect(result?.cssGzipSize).toBe(1048576);
       expect(result?.assets).toHaveLength(2);
       expect(result?.chunks).toHaveLength(1);
     });
@@ -46,6 +49,7 @@ describe('Report Module', () => {
       cssSize: 256 * 1024,    // 256KB
       htmlSize: 128 * 1024,   // 128KB
       otherSize: 128 * 1024,  // 128KB
+      totalGzipSize: 384 * 1024, // 384KB
       assets: [],
       chunks: [],
     };
@@ -55,6 +59,7 @@ describe('Report Module', () => {
       expect(markdown).toContain('### 📁 test-project');
       expect(markdown).toContain('**Path:** `path/to/file.json`');
       expect(markdown).toContain('1.0 MB');
+      expect(markdown).toContain('384.0 KB');
       expect(markdown).toContain('512.0 KB');
       expect(markdown).toContain('⚠️ **No baseline data found**');
       expect(markdown).toMatchSnapshot();
@@ -64,6 +69,7 @@ describe('Report Module', () => {
       const baseline = {
         ...mockAnalysis,
         totalSize: 512 * 1024, // 512KB (smaller)
+        totalGzipSize: 256 * 1024,
       };
       const markdown = generateProjectMarkdown('test-project', 'path/to/file.json', mockAnalysis, baseline);
       expect(markdown).toContain('### 📁 test-project');
@@ -86,6 +92,7 @@ describe('Report Module', () => {
       cssSize: 256 * 1024,
       htmlSize: 128 * 1024,
       otherSize: 128 * 1024,
+      totalGzipSize: 384 * 1024,
       assets: [],
       chunks: [],
     };
@@ -100,6 +107,7 @@ describe('Report Module', () => {
       const baseline = {
         ...mockAnalysis,
         totalSize: 512 * 1024,
+        totalGzipSize: 256 * 1024,
       };
       await generateBundleAnalysisReport(mockAnalysis, baseline);
       // GitHub Actions summary is mocked in setup.ts
@@ -107,4 +115,3 @@ describe('Report Module', () => {
     });
   });
 });
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { setFailed, getInput, summary } from '@actions/core';
 import { uploadArtifact, hashPath } from './upload';
 import { downloadArtifactByCommitHash } from './download';
 import { GitHubService } from './github';
-import { loadSizeData, generateSizeReport, parseRsdoctorData, generateBundleAnalysisReport, BundleAnalysis, generateProjectMarkdown, formatBytes, calculateDiff } from './report';
+import { loadSizeData, generateSizeReport, parseRsdoctorData, generateBundleAnalysisReport, BundleAnalysis, generateProjectMarkdown, formatBytes, calculateDiff, enrichRsdoctorDataWithGzip } from './report';
 import { analyzeWithAI, AIAnalysisResult } from './ai-analysis';
 import path from 'path';
 import * as fs from 'fs';
@@ -101,6 +101,33 @@ interface ProjectReport {
   baselineUsedFallback?: boolean;
   baselineLatestCommitHash?: string;
   aiAnalysis?: AIAnalysisResult | null;
+}
+
+function hasBundleAnalysisChange(current: BundleAnalysis, baseline: BundleAnalysis | null): boolean {
+  if (!baseline) return true;
+
+  const hasMetricChanged = (currentSize?: number, baselineSize?: number): boolean => {
+    if (typeof currentSize !== 'number' || typeof baselineSize !== 'number') return false;
+    if (baselineSize === 0 || isNaN(baselineSize)) return false;
+    return currentSize - baselineSize !== 0;
+  };
+
+  return (
+    hasMetricChanged(current.totalSize, baseline.totalSize) ||
+    hasMetricChanged(current.totalGzipSize, baseline.totalGzipSize)
+  );
+}
+
+function formatGzipSize(analysis: BundleAnalysis): string {
+  return typeof analysis.totalGzipSize === 'number' ? formatBytes(analysis.totalGzipSize) : '-';
+}
+
+function calculateGzipDiff(current: BundleAnalysis, baseline?: BundleAnalysis | null): { value: string; emoji: string } {
+  if (typeof current.totalGzipSize !== 'number' || typeof baseline?.totalGzipSize !== 'number') {
+    return { value: '-', emoji: '' };
+  }
+
+  return calculateDiff(current.totalGzipSize, baseline.totalGzipSize);
 }
 
 export function extractProjectName(filePath: string): string {
@@ -388,6 +415,7 @@ async function processSingleFile(
       console.log('🔄 Detected push event to target branch - uploading artifacts');
       
       for (const fullPath of matchedFiles) {
+        enrichRsdoctorDataWithGzip(fullPath);
         const uploadResponse = await uploadArtifact(fullPath, currentCommitHash);
         
         if (typeof uploadResponse.id !== 'number') {
@@ -452,6 +480,7 @@ async function processSingleFile(
         
         // For workflow_dispatch, also upload artifacts
         if (isDispatch) {
+          enrichRsdoctorDataWithGzip(fullPath);
           const uploadResponse = await uploadArtifact(fullPath, currentCommitHash);
           if (typeof uploadResponse.id !== 'number') {
             console.warn(`⚠️ Artifact upload failed for ${fullPath}`);
@@ -513,15 +542,7 @@ async function processSingleFile(
         let projectsWithChanges = 0;
         for (const report of reportsWithCurrent) {
           if (!report.current) continue;
-          if (!report.baseline) {
-            projectsWithChanges++;
-            continue;
-          }
-          const currentSize = report.current.totalSize;
-          const baselineSize = report.baseline.totalSize;
-          if (baselineSize === 0 || isNaN(baselineSize)) continue;
-          const diff = currentSize - baselineSize;
-          if (diff !== 0) {
+          if (hasBundleAnalysisChange(report.current, report.baseline)) {
             projectsWithChanges++;
           }
         }
@@ -538,16 +559,7 @@ async function processSingleFile(
         let hasChanges = false;
         for (const report of reportsWithCurrent) {
           if (!report.current) continue;
-          if (!report.baseline) {
-            hasChanges = true; // No baseline means we can't compare, show it
-            break;
-          }
-          const currentSize = report.current.totalSize;
-          const baselineSize = report.baseline.totalSize;
-          if (baselineSize === 0 || isNaN(baselineSize)) continue;
-          const diff = currentSize - baselineSize;
-          // Show if there's any non-zero change
-          if (diff !== 0) {
+          if (hasBundleAnalysisChange(report.current, report.baseline)) {
             hasChanges = true;
             break;
           }
@@ -556,8 +568,8 @@ async function processSingleFile(
         // Use 'open' attribute if there are changes, otherwise keep it collapsed
         const detailsTag = hasChanges ? '<details open>\n' : '<details>\n';
         commentBody += `${detailsTag}<summary><b>📊 Quick Summary</b></summary>\n\n`;
-        commentBody += '| Project | Total Size | Change |\n';
-        commentBody += '|---------|------------|--------|\n';
+        commentBody += '| Project | Total Size | Gzip Size | Change | Gzip Change |\n';
+        commentBody += '|---------|------------|-----------|--------|-------------|\n';
         
         for (const report of reportsWithCurrent) {
           if (!report.current) continue;
@@ -565,7 +577,8 @@ async function processSingleFile(
           const baselineSize = report.baseline?.totalSize || 0;
           const diff = report.baseline ? calculateDiff(currentSize, baselineSize) : { value: '-', emoji: '' };
           const sizeStr = formatBytes(currentSize);
-          commentBody += `| ${report.projectName} | ${sizeStr} | ${diff.emoji} ${diff.value} |\n`;
+          const gzipDiff = calculateGzipDiff(report.current, report.baseline);
+          commentBody += `| ${report.projectName} | ${sizeStr} | ${formatGzipSize(report.current)} | ${diff.emoji} ${diff.value} | ${gzipDiff.emoji} ${gzipDiff.value} |\n`;
         }
         
         commentBody += '\n</details>\n\n';
@@ -575,13 +588,7 @@ async function processSingleFile(
 
       const hasSignificantChanges = (report: ProjectReport): boolean => {
         if (!report.current) return false;
-        if (!report.baseline) return true; // No baseline means we can't compare, show it
-        const currentSize = report.current.totalSize;
-        const baselineSize = report.baseline.totalSize;
-        if (baselineSize === 0 || isNaN(baselineSize)) return false;
-        const diff = currentSize - baselineSize;
-        // Show detailed report if there's any change (not zero)
-        return diff !== 0;
+        return hasBundleAnalysisChange(report.current, report.baseline);
       };
       
       // Filter reports with changes

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,8 +1,11 @@
 import { summary } from '@actions/core';
 import * as fs from 'fs';
+import * as path from 'path';
+import { gzipSync } from 'zlib';
 
 export interface SizeData {
   totalSize: number;
+  totalGzipSize?: number;
   files: Array<{
     path: string;
     size: number;
@@ -18,6 +21,7 @@ export interface RsdoctorData {
         id: number;
         path: string;
         size: number;
+        gzipSize?: number;
         chunks: string[];
       }>;
       chunks: Array<{
@@ -37,9 +41,15 @@ export interface BundleAnalysis {
   cssSize: number;
   htmlSize: number;
   otherSize: number;
+  totalGzipSize?: number;
+  jsGzipSize?: number;
+  cssGzipSize?: number;
+  htmlGzipSize?: number;
+  otherGzipSize?: number;
   assets: Array<{
     path: string;
     size: number;
+    gzipSize?: number;
     type: 'js' | 'css' | 'html' | 'other';
   }>;
   chunks: Array<{
@@ -79,6 +89,69 @@ export function formatBytes(bytes: number): string {
   return `${isNegative ? '-' : ''}${value} ${sizes[i]}`;
 }
 
+function formatOptionalBytes(bytes?: number): string {
+  return typeof bytes === 'number' && !isNaN(bytes) ? formatBytes(bytes) : '-';
+}
+
+function calculateOptionalDiff(current?: number, baseline?: number): string {
+  if (typeof current !== 'number' || typeof baseline !== 'number') return '-';
+  return calculateDiff(current, baseline).value;
+}
+
+function resolveAssetPath(assetPath: string, dataFilePath: string): string | null {
+  const relativeDataPath = path.relative(process.cwd(), dataFilePath);
+  const isDownloadedArtifact = relativeDataPath.split(path.sep)[0] === 'temp-artifact';
+  const candidates = [
+    path.isAbsolute(assetPath) && !isDownloadedArtifact ? assetPath : null,
+    isDownloadedArtifact ? null : path.resolve(process.cwd(), assetPath),
+    path.resolve(path.dirname(dataFilePath), assetPath),
+    path.resolve(path.dirname(dataFilePath), '..', assetPath),
+  ].filter(Boolean) as string[];
+
+  return candidates.find(candidate => fs.existsSync(candidate)) || null;
+}
+
+function getAssetGzipSize(asset: { path: string; gzipSize?: number }, dataFilePath: string): number | undefined {
+  if (typeof asset.gzipSize === 'number' && !isNaN(asset.gzipSize)) {
+    return asset.gzipSize;
+  }
+
+  const assetPath = resolveAssetPath(asset.path, dataFilePath);
+  if (!assetPath) return undefined;
+
+  return gzipSync(fs.readFileSync(assetPath)).length;
+}
+
+export function enrichRsdoctorDataWithGzip(filePath: string): boolean {
+  try {
+    if (!fs.existsSync(filePath)) return false;
+
+    const data: RsdoctorData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const assets = data.data?.chunkGraph?.assets;
+    if (!Array.isArray(assets)) return false;
+
+    let updated = false;
+    for (const asset of assets) {
+      if (typeof asset.gzipSize === 'number' && !isNaN(asset.gzipSize)) continue;
+
+      const gzipSize = getAssetGzipSize(asset, filePath);
+      if (typeof gzipSize === 'number') {
+        asset.gzipSize = gzipSize;
+        updated = true;
+      }
+    }
+
+    if (updated) {
+      fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+    }
+
+    return updated;
+  } catch (error) {
+    console.warn(`Failed to enrich rsdoctor data with gzip sizes from ${filePath}:`, error);
+    return false;
+  }
+}
+
 export function parseRsdoctorData(filePath: string): BundleAnalysis | null {
   try {
     if (!fs.existsSync(filePath)) {
@@ -103,27 +176,42 @@ export function parseRsdoctorData(filePath: string): BundleAnalysis | null {
     let cssSize = 0;
     let htmlSize = 0;
     let otherSize = 0;
+    let totalGzipSize = 0;
+    let jsGzipSize = 0;
+    let cssGzipSize = 0;
+    let htmlGzipSize = 0;
+    let otherGzipSize = 0;
+    let hasGzipSize = false;
 
-    const assetAnalysis = assets.reduce((acc: Array<{ path: string; size: number; type: 'js' | 'css' | 'html' | 'other' }>, asset) => {
+    const assetAnalysis = assets.reduce((acc: Array<{ path: string; size: number; gzipSize?: number; type: 'js' | 'css' | 'html' | 'other' }>, asset) => {
       if (excludedExtensions.some(ext => asset.path.endsWith(ext))) return acc;
 
       totalSize += asset.size;
+      const gzipSize = getAssetGzipSize(asset, filePath);
+      if (typeof gzipSize === 'number') {
+        totalGzipSize += gzipSize;
+        hasGzipSize = true;
+      }
 
       let type: 'js' | 'css' | 'html' | 'other' = 'other';
       if (asset.path.endsWith('.js')) {
         type = 'js';
         jsSize += asset.size;
+        if (typeof gzipSize === 'number') jsGzipSize += gzipSize;
       } else if (asset.path.endsWith('.css')) {
         type = 'css';
         cssSize += asset.size;
+        if (typeof gzipSize === 'number') cssGzipSize += gzipSize;
       } else if (asset.path.endsWith('.html')) {
         type = 'html';
         htmlSize += asset.size;
+        if (typeof gzipSize === 'number') htmlGzipSize += gzipSize;
       } else {
         otherSize += asset.size;
+        if (typeof gzipSize === 'number') otherGzipSize += gzipSize;
       }
 
-      acc.push({ path: asset.path, size: asset.size, type });
+      acc.push({ path: asset.path, size: asset.size, gzipSize, type });
       return acc;
     }, []);
     
@@ -139,6 +227,11 @@ export function parseRsdoctorData(filePath: string): BundleAnalysis | null {
       cssSize,
       htmlSize,
       otherSize,
+      totalGzipSize: hasGzipSize ? totalGzipSize : undefined,
+      jsGzipSize: hasGzipSize ? jsGzipSize : undefined,
+      cssGzipSize: hasGzipSize ? cssGzipSize : undefined,
+      htmlGzipSize: hasGzipSize ? htmlGzipSize : undefined,
+      otherGzipSize: hasGzipSize ? otherGzipSize : undefined,
       assets: assetAnalysis,
       chunks: chunkAnalysis
     };
@@ -159,6 +252,9 @@ export function loadSizeData(filePath: string): SizeData | null {
     
     if (!data.totalSize && data.files) {
       data.totalSize = data.files.reduce((sum: number, file: any) => sum + (file.size || 0), 0);
+    }
+    if (!data.totalGzipSize && data.files?.some((file: any) => typeof file.gzipSize === 'number')) {
+      data.totalGzipSize = data.files.reduce((sum: number, file: any) => sum + (file.gzipSize || 0), 0);
     }
     
     return data;
@@ -235,6 +331,7 @@ export function generateProjectMarkdown(
   markdown += '| Metric | Current | Baseline | Change |\n';
   markdown += '|--------|---------|----------|--------|\n';
   markdown += `| 📊 Total Size | ${formatBytes(current.totalSize)} | ${baseline ? formatBytes(baseline.totalSize) : '-'} | ${baseline ? calculateDiff(current.totalSize, baseline.totalSize).value : '-'} |\n`;
+  markdown += `| 🗜️ Gzip Size | ${formatOptionalBytes(current.totalGzipSize)} | ${baseline ? formatOptionalBytes(baseline.totalGzipSize) : '-'} | ${baseline ? calculateOptionalDiff(current.totalGzipSize, baseline.totalGzipSize) : '-'} |\n`;
   markdown += `| 📄 JavaScript | ${formatBytes(current.jsSize)} | ${baseline ? formatBytes(baseline.jsSize) : '-'} | ${baseline ? calculateDiff(current.jsSize, baseline.jsSize).value : '-'} |\n`;
   markdown += `| 🎨 CSS | ${formatBytes(current.cssSize)} | ${baseline ? formatBytes(baseline.cssSize) : '-'} | ${baseline ? calculateDiff(current.cssSize, baseline.cssSize).value : '-'} |\n`;
   markdown += `| 🌐 HTML | ${formatBytes(current.htmlSize)} | ${baseline ? formatBytes(baseline.htmlSize) : '-'} | ${baseline ? calculateDiff(current.htmlSize, baseline.htmlSize).value : '-'} |\n`;
@@ -285,6 +382,12 @@ export async function generateBundleAnalysisReport(
       { data: formatBytes(current.totalSize), header: false },
       { data: baseline ? formatBytes(baseline.totalSize) : formatBytes(current.totalSize), header: false },
       { data: baseline ? calculateDiff(current.totalSize, baseline.totalSize).value : '0', header: false }
+    ],
+    [
+      { data: '🗜️ Gzip Size', header: false },
+      { data: formatOptionalBytes(current.totalGzipSize), header: false },
+      { data: baseline ? formatOptionalBytes(baseline.totalGzipSize) : formatOptionalBytes(current.totalGzipSize), header: false },
+      { data: baseline ? calculateOptionalDiff(current.totalGzipSize, baseline.totalGzipSize) : '0', header: false }
     ],
     [
       { data: '📄 JavaScript', header: false },
@@ -341,6 +444,14 @@ export async function generateSizeReport(current: SizeData, baseline?: SizeData)
       { data: baseline ? formatBytes(baseline.totalSize) : '0', header: false }
     ]
   ];
+
+  if (typeof current.totalGzipSize === 'number' || typeof baseline?.totalGzipSize === 'number') {
+    reportTable.push([
+      { data: '🗜️ Gzip Size', header: false },
+      { data: formatOptionalBytes(current.totalGzipSize), header: false },
+      { data: baseline ? formatOptionalBytes(baseline.totalGzipSize) : '0', header: false }
+    ]);
+  }
   
   await summary
     .addTable(reportTable)
@@ -349,17 +460,20 @@ export async function generateSizeReport(current: SizeData, baseline?: SizeData)
   if (current.files && current.files.length > 0) {
     await summary.addHeading('📄 File Details', 3);
     
+    const hasFileGzipSize = current.files.some(file => typeof file.gzipSize === 'number');
     const fileTable = [
       [
         { data: 'File', header: true },
-        { data: 'Size', header: true }
+        { data: 'Size', header: true },
+        ...(hasFileGzipSize ? [{ data: 'Gzip Size', header: true }] : [])
       ]
     ];
     
     for (const file of current.files) {
       fileTable.push([
         { data: file.path, header: false },
-        { data: formatBytes(file.size), header: false }
+        { data: formatBytes(file.size), header: false },
+        ...(hasFileGzipSize ? [{ data: formatOptionalBytes(file.gzipSize), header: false }] : [])
       ]);
     }
     


### PR DESCRIPTION
## Summary

- Add gzip size collection for Rsdoctor assets, using existing `gzipSize` data when available and calculating it from build assets when needed.
- Persist gzip sizes into uploaded baseline data so future PR comparisons can show gzip deltas.
- Surface gzip size and gzip change in GitHub Actions summaries and PR comments.
