### PR TITLE
[codex] skip AI analysis when bundle is unchanged

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -129019,7 +129019,7 @@ ${diffStr}
             } catch (e) {
                 console.warn(`⚠️ Failed to upload diff html for ${projectName}: ${e}`);
             }
-            if (aiToken) try {
+            if (aiToken && hasBundleAnalysisChange(currentBundleAnalysis, report.baseline)) try {
                 const diffJsonPath = external_path_default().join(tempOutDir, `rsdoctor-diff-${projectName}.json`);
                 const defaultDiffJsonPath = external_path_default().join(tempOutDir, 'rsdoctor-diff.json');
                 try {
@@ -129056,6 +129056,7 @@ ${diffStr}
             } catch (e) {
                 console.warn(`⚠️ Failed to generate JSON diff for AI analysis: ${e}`);
             }
+            else if (aiToken) console.log(`ℹ️  No bundle changes detected for ${projectName}, skipping AI analysis`);
         } catch (e) {
             console.warn(`⚠️ rsdoctor bundle-diff failed for ${projectName}: ${e}`);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,7 +306,7 @@ async function processSingleFile(
       }
 
       // Generate JSON diff for AI analysis (requires @rsdoctor/cli >= 1.5.6-canary.0)
-      if (aiToken) {
+      if (aiToken && hasBundleAnalysisChange(currentBundleAnalysis, report.baseline)) {
         try {
           const diffJsonPath = path.join(tempOutDir, `rsdoctor-diff-${projectName}.json`);
           const defaultDiffJsonPath = path.join(tempOutDir, 'rsdoctor-diff.json');
@@ -341,6 +341,8 @@ async function processSingleFile(
         } catch (e) {
           console.warn(`⚠️ Failed to generate JSON diff for AI analysis: ${e}`);
         }
+      } else if (aiToken) {
+        console.log(`ℹ️  No bundle changes detected for ${projectName}, skipping AI analysis`);
       }
     } catch (e) {
       console.warn(`⚠️ rsdoctor bundle-diff failed for ${projectName}: ${e}`);


### PR DESCRIPTION
## Summary

- Skip bundle diff JSON generation and AI analysis when `AI_TOKEN` is configured but the current bundle has no total size or gzip size changes versus baseline.
- Keep a lightweight log message so the action explains why AI analysis was skipped.
